### PR TITLE
Improve mobile nav spacing and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Personal Resume Site
+
+This repository contains the source code for Antonio Iadicicco's resume website hosted via GitHub Pages.
+
+## Development
+
+Changes can be previewed locally by opening `index.html` in a browser. The site uses a small amount of JavaScript for animations and responsive navigation.
+
+Styles are defined in `style.css`. On screens narrower than 600px, the navigation collapses into a sidebar that can be toggled with the menu button in the header.
+
+## Deployment
+
+Pushes to the `main` branch are automatically published through GitHub Pages. No additional build steps are required.
+

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <header>
+    <button id="menu-btn" aria-label="Menu" type="button">&#9776;</button>
     <h1>Antonio Iadicicco</h1>
     <nav>
       <ul>
@@ -167,6 +168,11 @@ document.addEventListener("DOMContentLoaded",()=>{
     entries.forEach(e=>{if(e.isIntersecting)e.target.classList.add("show")});
   },{threshold:0.1});
   document.querySelectorAll("section").forEach(s=>obs.observe(s));
+
+  const menuBtn=document.getElementById("menu-btn");
+  const nav=document.querySelector("nav");
+  menuBtn.addEventListener("click",()=>nav.classList.toggle("open"));
+  nav.querySelectorAll("a").forEach(a=>a.addEventListener("click",()=>nav.classList.remove("open")));
 });
 </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -106,3 +106,56 @@ footer {
     font-size: 14px;
     color: #666;
 }
+
+#menu-btn {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+@media (max-width: 600px) {
+    header {
+        padding: 10px 20px;
+        justify-content: center;
+    }
+
+    header h1 {
+        font-size: 24px;
+        margin: 0;
+    }
+
+    #menu-btn {
+        display: block;
+        position: absolute;
+        left: 20px;
+    }
+
+    nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 200px;
+        height: 100%;
+        background: #fff;
+        border-right: 1px solid #eee;
+        padding: 60px 20px 20px;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        z-index: 999;
+    }
+
+    nav.open {
+        transform: translateX(0);
+    }
+
+    nav ul {
+        width: 100%;
+    }
+
+    nav ul li {
+        display: block;
+        margin: 15px 0;
+    }
+}


### PR DESCRIPTION
## Summary
- center header on small screens and position menu button absolutely
- add accessible label to the menu button
- add project documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f6ca7b92c8333abaedeb44a43d063