### PR TITLE
Add mobile side drawer navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -109,10 +109,11 @@ nav ul li a.active {
 .side-drawer {
   position: fixed;
   top: 0;
+  left: 0;
   right: -100%;
   width: 100%;
   height: 100%;
-  background: #000000;
+  background-color: #000000;
   padding: 60px 20px 20px;
   transition: right 0.3s ease;
   z-index: 1001;
@@ -147,7 +148,7 @@ nav ul li a.active {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(4px);
   z-index: 1000;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -72,7 +72,7 @@ nav ul li a {
   color: #f5f5f7;
   text-decoration: none;
   font-weight: 400;
-  font-size: 12px;
+  font-size: 14px;
   padding: 8px 12px;
   border-radius: 18px;
   transition: all 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
@@ -129,8 +129,8 @@ nav ul li a.active {
 .side-drawer a {
   color: #f5f5f7;
   text-decoration: none;
-  font-size: 14px;
-  opacity: 0.8;
+  font-size: 18px;
+  opacity: 0.9;
 }
 
 .side-drawer a.active {

--- a/src/App.css
+++ b/src/App.css
@@ -108,12 +108,12 @@ nav ul li a.active {
 
 .side-drawer {
   position: fixed;
-  top: 44px;
-  right: -260px;
-  width: 260px;
-  height: calc(100% - 44px);
+  top: 0;
+  right: -100%;
+  width: 100%;
+  height: 100%;
   background: #000000;
-  padding: 20px;
+  padding: 60px 20px 20px;
   transition: right 0.3s ease;
   z-index: 1001;
 }
@@ -143,7 +143,7 @@ nav ul li a.active {
 
 .drawer-overlay {
   position: fixed;
-  top: 44px;
+  top: 0;
   left: 0;
   right: 0;
   bottom: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -90,6 +90,69 @@ nav ul li a.active {
   background: rgba(255, 255, 255, 0.15);
 }
 
+.mobile-menu-button {
+  display: none;
+  background: none;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+}
+
+.hamburger-line {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: #f5f5f7;
+  margin: 4px 0;
+}
+
+.side-drawer {
+  position: fixed;
+  top: 44px;
+  right: -260px;
+  width: 260px;
+  height: calc(100% - 44px);
+  background: #000000;
+  padding: 20px;
+  transition: right 0.3s ease;
+  z-index: 1001;
+}
+
+.side-drawer ul {
+  padding: 0;
+}
+
+.side-drawer li {
+  margin-bottom: 16px;
+}
+
+.side-drawer a {
+  color: #f5f5f7;
+  text-decoration: none;
+  font-size: 14px;
+  opacity: 0.8;
+}
+
+.side-drawer a.active {
+  opacity: 1;
+}
+
+.side-drawer.open {
+  right: 0;
+}
+
+.drawer-overlay {
+  position: fixed;
+  top: 44px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+}
+
+
 main {
   padding-top: 0;
 }
@@ -361,6 +424,14 @@ footer {
 
   nav ul {
     gap: 0;
+  }
+
+  .desktop-nav {
+    display: none;
+  }
+
+  .mobile-menu-button {
+    display: block;
   }
 
   nav ul li a {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,9 +2,17 @@ import { useState, useEffect } from 'react'
 
 function Header() {
   const [activeSection, setActiveSection] = useState('')
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  const toggleDrawer = () => {
+    setDrawerOpen((prev) => !prev)
+  }
+
+  const closeDrawer = () => setDrawerOpen(false)
 
   const scrollToSection = (sectionId) => {
     document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth' })
+    closeDrawer()
   }
 
   useEffect(() => {
@@ -41,7 +49,7 @@ function Header() {
     <header>
       <div className="header-content">
         <h1>Antonio Iadicicco</h1>
-        <nav>
+        <nav className="desktop-nav">
           <ul>
             {navItems.map((item) => (
               <li key={item.id}>
@@ -59,6 +67,34 @@ function Header() {
             ))}
           </ul>
         </nav>
+        <button
+          className="mobile-menu-button"
+          onClick={toggleDrawer}
+          aria-label="Toggle navigation"
+        >
+          <span className="hamburger-line" />
+          <span className="hamburger-line" />
+          <span className="hamburger-line" />
+        </button>
+      </div>
+      {drawerOpen && <div className="drawer-overlay" onClick={closeDrawer} />}
+      <div className={`side-drawer ${drawerOpen ? 'open' : ''}`}>
+        <ul>
+          {navItems.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={activeSection === item.id ? 'active' : ''}
+                onClick={(e) => {
+                  e.preventDefault()
+                  scrollToSection(item.id)
+                }}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
     </header>
   )


### PR DESCRIPTION
## Summary
- implement a mobile side drawer with toggle button
- adjust responsive styles for the drawer
- update navigation logic to close drawer on click

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fab5bd8a48333bc1636088fc7ce9a