### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -922,3 +922,100 @@ footer {
     font-size: 17px;
   }
 }
+
+/* Dark mode styles */
+body.dark-mode {
+  background: #000000;
+  color: #f5f5f7;
+}
+
+body.dark-mode section {
+  background: #1d1d1f;
+  color: #f5f5f7;
+}
+
+body.dark-mode section:nth-child(even) {
+  background: #000000;
+}
+
+body.dark-mode footer {
+  background: #000000;
+  color: #86868b;
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 8px 12px;
+}
+
+.theme-toggle input {
+  display: none;
+}
+
+.theme-toggle .switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 20px;
+  margin-left: 8px;
+  transition: background 0.3s ease;
+}
+
+.theme-toggle .switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: #ffffff;
+  border-radius: 50%;
+  transition: transform 0.3s ease;
+}
+
+.theme-toggle input:checked + .switch {
+  background: #0071e3;
+}
+
+.theme-toggle input:checked + .switch::after {
+  transform: translateX(16px);
+}
+
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3,
+body.dark-mode h4,
+body.dark-mode h5,
+body.dark-mode h6,
+body.dark-mode p,
+body.dark-mode li,
+body.dark-mode a,
+body.dark-mode .section-headline,
+body.dark-mode .feature-headline,
+body.dark-mode .section-subhead,
+body.dark-mode .about-tagline,
+body.dark-mode .skill-card-title {
+  color: #f5f5f7;
+}
+
+body.dark-mode .feature-item,
+body.dark-mode .about-card,
+body.dark-mode .project-card,
+body.dark-mode .skill-card,
+body.dark-mode .skills-carousel-container {
+  background: #1d1d1f;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .skill-tag {
+  background-color: #333333;
+  color: #f5f5f7;
+}
+
+body.dark-mode .carousel-arrow {
+  background-color: rgba(0, 0, 0, 0.85);
+  color: #f5f5f7;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -677,6 +677,7 @@ footer {
 .skill-card {
   box-sizing: border-box;
   background-color: #f5f5f7;
+  border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 18px;
   overflow: hidden;
   flex-shrink: 0;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,6 +3,12 @@ import { useState, useEffect } from 'react'
 function Header() {
   const [activeSection, setActiveSection] = useState('')
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') === 'dark'
+    }
+    return false
+  })
 
   const scrollToSection = (sectionId) => {
     document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth' })
@@ -40,6 +46,11 @@ function Header() {
       document.body.style.overflow = ''
     }
   }, [isDrawerOpen])
+
+  useEffect(() => {
+    document.body.classList.toggle('dark-mode', isDarkMode)
+    localStorage.setItem('theme', isDarkMode ? 'dark' : 'light')
+  }, [isDarkMode])
 
   const navItems = [
     { id: 'about', label: 'About' },
@@ -89,6 +100,15 @@ function Header() {
             >
               Download Resume
             </button>
+            <label className="theme-toggle">
+              <input
+                type="checkbox"
+                checked={isDarkMode}
+                onChange={() => setIsDarkMode(!isDarkMode)}
+                aria-label="Toggle dark mode"
+              />
+              <span className="switch"></span>
+            </label>
           </nav>
           <button 
             className="menu-button"
@@ -132,7 +152,7 @@ function Header() {
             </li>
           ))}
           <li className="drawer-resume-button">
-            <button 
+            <button
               className="resume-button mobile"
               onClick={() => {
                 handleResumeDownload()
@@ -142,6 +162,17 @@ function Header() {
             >
               Download Resume
             </button>
+          </li>
+          <li>
+            <label className="theme-toggle">
+              <input
+                type="checkbox"
+                checked={isDarkMode}
+                onChange={() => setIsDarkMode(!isDarkMode)}
+                aria-label="Toggle dark mode"
+              />
+              <span className="switch"></span>
+            </label>
           </li>
         </ul>
       </nav>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,10 +9,13 @@ function Header() {
     }
     return false
   })
-
   const scrollToSection = (sectionId) => {
     document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth' })
     setIsDrawerOpen(false)
+  }
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   useEffect(() => {
@@ -72,10 +75,15 @@ function Header() {
   }
 
   return (
-    <>
-      <header>
+    <>      <header>
         <div className="header-content">
-          <h1>Antonio Iadicicco</h1>
+          <h1 
+            onClick={scrollToTop}
+            style={{ cursor: 'pointer' }}
+            title="Back to top"
+          >
+            AI
+          </h1>
           <nav className="desktop-nav">
             <ul>
               {navItems.map((item) => (


### PR DESCRIPTION
## Summary
- add a dark mode state and persistence in the header
- provide toggle switches in the desktop and mobile navigation
- style dark mode, override colors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683ff74e2cec8333b1561646ca67d7a0