### PR TITLE
Move dark mode toggle into mobile navbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -848,6 +848,10 @@ footer {
     display: flex;
   }
 
+  .mobile-theme-toggle {
+    display: flex;
+  }
+
   .resume-button:not(.mobile) {
     display: none;
   }
@@ -983,6 +987,10 @@ body.dark-mode footer {
 
 .theme-toggle input:checked + .switch::after {
   transform: translateX(16px);
+}
+
+.mobile-theme-toggle {
+  display: none;
 }
 
 body.dark-mode h1,

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -118,7 +118,16 @@ function Header() {
               <span className="switch"></span>
             </label>
           </nav>
-          <button 
+          <label className="theme-toggle mobile-theme-toggle">
+            <input
+              type="checkbox"
+              checked={isDarkMode}
+              onChange={() => setIsDarkMode(!isDarkMode)}
+              aria-label="Toggle dark mode"
+            />
+            <span className="switch"></span>
+          </label>
+          <button
             className="menu-button"
             onClick={() => setIsDrawerOpen(!isDrawerOpen)}
             aria-label="Menu"
@@ -170,17 +179,6 @@ function Header() {
             >
               Download Resume
             </button>
-          </li>
-          <li>
-            <label className="theme-toggle">
-              <input
-                type="checkbox"
-                checked={isDarkMode}
-                onChange={() => setIsDarkMode(!isDarkMode)}
-                aria-label="Toggle dark mode"
-              />
-              <span className="switch"></span>
-            </label>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- show a dark mode toggle beside the hamburger menu on mobile
- remove the toggle from the drawer
- style the new mobile toggle

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68412114383883339188f4566f193873